### PR TITLE
fix: guard choices[0] and message=None before content access

### DIFF
--- a/code/C4/04_text_to_metadata_filter_v2.py
+++ b/code/C4/04_text_to_metadata_filter_v2.py
@@ -116,6 +116,8 @@ JSON指令:"""
     
     try:
         import json
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         instruction_str = response.choices[0].message.content
         instruction = json.loads(instruction_str)
         print(f"--- 生成的排序指令: {instruction} ---")

--- a/code/C5/02_function_calling_example.py
+++ b/code/C5/02_function_calling_example.py
@@ -15,6 +15,8 @@ def send_messages(messages, tools=None):
         tools=tools,
         tool_choice="auto",  # 让模型自主决定是否调用工具
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message
 
 # 1. 定义工具（函数）的 Schema

--- a/code/C9/agent(代码系ai生成)/recipe_ai_agent.py
+++ b/code/C9/agent(代码系ai生成)/recipe_ai_agent.py
@@ -112,8 +112,10 @@ class KimiRecipeAgent:
                     stream=False
                 )
                 
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 return response.choices[0].message.content
-                    
+
             except Exception as e:
                 print(f"API调用错误 (尝试 {attempt + 1}): {str(e)}")
                 if attempt < max_retries - 1:

--- a/code/C9/rag_modules/generation_integration.py
+++ b/code/C9/rag_modules/generation_integration.py
@@ -82,8 +82,10 @@ class GenerationIntegrationModule:
                 max_tokens=self.max_tokens
             )
             
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             return response.choices[0].message.content.strip()
-            
+
         except Exception as e:
             logger.error(f"LightRAG答案生成失败: {e}")
             return f"抱歉，生成回答时出现错误：{str(e)}"

--- a/code/C9/rag_modules/graph_indexing.py
+++ b/code/C9/rag_modules/graph_indexing.py
@@ -285,6 +285,8 @@ class GraphIndexingModule:
                 max_tokens=200
             )
             
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             result = json.loads(response.choices[0].message.content.strip())
             return result.get("keywords", [])
             

--- a/code/C9/rag_modules/graph_rag_retrieval.py
+++ b/code/C9/rag_modules/graph_rag_retrieval.py
@@ -240,8 +240,10 @@ class GraphRAGRetrieval:
                 max_tokens=1000
             )
             
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             result = json.loads(response.choices[0].message.content.strip())
-            
+
             return GraphQuery(
                 query_type=QueryType(result.get("query_type", "subgraph")),
                 source_entities=result.get("source_entities", []),

--- a/code/C9/rag_modules/hybrid_retrieval.py
+++ b/code/C9/rag_modules/hybrid_retrieval.py
@@ -201,6 +201,8 @@ class HybridRetrievalModule:
                 max_tokens=500
             )
             
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             result = json.loads(response.choices[0].message.content.strip())
             entity_keywords = result.get("entity_keywords", [])
             topic_keywords = result.get("topic_keywords", [])

--- a/code/C9/rag_modules/intelligent_query_router.py
+++ b/code/C9/rag_modules/intelligent_query_router.py
@@ -119,8 +119,10 @@ class IntelligentQueryRouter:
                 max_tokens=800
             )
             
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             result = json.loads(response.choices[0].message.content.strip())
-            
+
             analysis = QueryAnalysis(
                 query_complexity=result.get("query_complexity", 0.5),
                 relationship_intensity=result.get("relationship_intensity", 0.5),


### PR DESCRIPTION
## Summary

OpenAI-compatible APIs can return **empty `choices`** on error or rate-limiting, causing `IndexError` at `choices[0]`. Gemini additionally returns `choices[0].message = None` on `PROHIBITED_CONTENT` safety filtering (HTTP 200 — no exception raised), causing `AttributeError` at `.content`.

This PR adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before every bare `choices[0].message.content` (or `.message`) access.

## Files changed (8 files, 8 sites)

- `code/C4/04_text_to_metadata_filter_v2.py` — metadata filter LLM call
- `code/C5/02_function_calling_example.py` — function calling example
- `code/C9/rag_modules/graph_rag_retrieval.py` — graph RAG query parsing
- `code/C9/rag_modules/intelligent_query_router.py` — query analysis
- `code/C9/rag_modules/generation_integration.py` — answer generation
- `code/C9/rag_modules/graph_indexing.py` — keyword extraction
- `code/C9/rag_modules/hybrid_retrieval.py` — hybrid retrieval keywords
- `code/C9/agent(代码系ai生成)/recipe_ai_agent.py` — recipe agent

## Verification

The Gemini `choices[0].message = None` crash is a documented production behavior on `PROHIBITED_CONTENT` safety filtering. Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule) found all 8 sites; post-fix scan returns 0 violations.