### PR TITLE
feat(C9): hybrid_search 加入父文档回填，消除菜谱截断导致的步骤不全问题

### DIFF
--- a/code/C9/config.py
+++ b/code/C9/config.py
@@ -28,6 +28,11 @@ class GraphRAGConfig:
     # 检索配置（LightRAG Round-robin策略）
     top_k: int = 5
 
+    # 父文档检索配置
+    enable_parent_doc_retrieval: bool = False  # 默认 False，不做父文档回填，直接把chunk当作上下文，有可能会出现步骤不全问题
+    parent_doc_top_n: int = 3                   # 仅 RRF 分前 N 名做父文档替换
+    parent_doc_max_chars: int = 4000            # 每篇父文档字符上限（兜底）
+
     # 生成配置
     temperature: float = 0.1
     max_tokens: int = 2048
@@ -61,6 +66,9 @@ class GraphRAGConfig:
             'embedding_model': self.embedding_model,
             'llm_model': self.llm_model,
             'top_k': self.top_k,
+            'enable_parent_doc_retrieval': self.enable_parent_doc_retrieval,
+            'parent_doc_top_n': self.parent_doc_top_n,
+            'parent_doc_max_chars': self.parent_doc_max_chars,
 
             'temperature': self.temperature,
             'max_tokens': self.max_tokens,

--- a/code/C9/rag_modules/hybrid_retrieval.py
+++ b/code/C9/rag_modules/hybrid_retrieval.py
@@ -88,6 +88,10 @@ class HybridRetrievalModule:
         # 初始化图索引
         self._build_graph_index()
 
+        # 初始化父文档映射，每个nodeid对应该chunk所属父文档的document
+        self._parent_doc_map = self._build_parent_doc_map()
+        logger.info(f"父文档映射构建完成，菜谱文档数: {len(self._parent_doc_map)}")
+
     @staticmethod
     def _tokenize_chinese(text: str) -> List[str]:
         """jieba 精确分词 + 停用词 / 空白 / 单字符过滤"""
@@ -708,6 +712,46 @@ class HybridRetrievalModule:
 
         return merged
 
+    def _build_parent_doc_map(self) -> Dict[str, Document]:
+        """{str(node_id): 整篇父菜谱 Document}，由分块前的 data_module.documents 懒建一次。"""
+        docs = getattr(self.data_module, "documents", None) or []
+        m: Dict[str, Document] = {}
+        for d in docs:
+            nid = d.metadata.get("node_id")
+            if nid is not None:
+                m[str(nid)] = d
+        return m
+
+    def _attach_parent_documents(self, docs: List[Document]) -> List[Document]:
+        """RRF 去重后，前 parent_doc_top_n 条且能在映射中找到父菜谱的，
+        用整篇父菜谱（超 parent_doc_max_chars 截断）替换 chunk；其余原样不变。
+        不改顺序/数量/排名，不 mutate 输入（被替换的造新 Document，未替换的直接传原对象）。"""
+        if getattr(self, "_parent_doc_map", None) is None:
+            self._parent_doc_map = self._build_parent_doc_map()
+        pmap = self._parent_doc_map
+        if not pmap:
+            logger.warning("父文档映射为空（data_module.documents 未就绪），父文档回填未生效，仍然使用原chunk填充上下文")
+            return docs
+        top_n = getattr(self.config, "parent_doc_top_n", 3)
+        max_chars = getattr(self.config, "parent_doc_max_chars", 4000)
+
+        out: List[Document] = []
+        for i, doc in enumerate(docs):
+            if i >= top_n:
+                out.append(doc)
+                continue
+            nid = doc.metadata.get("node_id")
+            key = str(nid if nid is not None else doc.metadata.get("parent_id"))
+            parent = pmap.get(key)
+            if parent is None:
+                out.append(doc)
+                continue
+            pc = parent.page_content or ""
+            if len(pc) > max_chars:
+                pc = pc[:max_chars] + "…（父文档已截断）"
+            out.append(Document(page_content=pc, metadata=dict(doc.metadata)))
+        return out
+
     def hybrid_search(self, query: str, top_k: int = 5) -> List[Document]:
         """
         混合检索：三路召回（图键值双层 + 向量 + BM25）→ RRF 融合
@@ -736,6 +780,10 @@ class HybridRetrievalModule:
             ],
             top_k=top_k,
         )
+
+        # 父文档回填（仅 hybrid_traditional 路；不改排名，仅换上下文内容）
+        if getattr(self.config, "enable_parent_doc_retrieval", False):
+            final_docs = self._attach_parent_documents(final_docs)
 
         logger.info(
             f"RRF 融合完成：dual={len(dual_docs)} vector={len(vector_docs)} "


### PR DESCRIPTION
## 问题

  Chapter 9 `hybrid_retrieval.py` 的 `hybrid_search` 在长菜谱上存在一个上下文不可靠问题：

  - `build_recipe_documents` 把步骤写进 page_content，但 `chunk_documents` 按 `\n## ` 二级标题切分，而步骤是 `### 第i步`
   三级标题 → 长菜谱步骤段被切到非首个 chunk
  - `hybrid_search` 按 `node_id` 去重，每道菜只保留一个胜出 chunk；长菜谱常是元数据/食材 chunk 胜出
  - 胜出哪个 chunk 受 `dual_level_retrieval` 的 LLM 关键词抽取（temperature=0.1）影响而**抖动** → 步骤/食材类问题的上下文**时对时错、不可复现**

  可复现的例子：同一道菜（节点 201003707）在同一次评测内，问"主要食材"答案 faithfulness 0.81（答对），问"制作步骤"faithfulness 0.25（答案自陈"没找到步骤"）—— 同节点命中，内容却因切块/去重进不了上下文。节点级 hit@5/recall@5/mrr 完全掩盖这一点（节点命中 ≠ 答题内容进上下文）。

  ## 改动概述

  引入父文档检索（parent-document / small-to-big）：

  - RRF 去重后，前 `parent_doc_top_n` 条且能定位到父菜谱的命中 chunk，整篇父菜谱内容替换该 chunk（超
 `parent_doc_max_chars` 截断兜底）
  - 仅在 `_rrf_merge` 之后做内容替换，**不改召回/排名/索引**；前 top_n 命中造新 Document、其余传原对象、映射为空早返回、不 mutate 输入
  - 父文档映射在 `initialize()` 一次性构建（懒加载）
  - 新增 config 开关 `enable_parent_doc_retrieval`（默认 `False`，关闭时行为与改前一致），`parent_doc_top_n` /
  `parent_doc_max_chars` 可调

  把"哪个 chunk 胜出决定步骤在不在上下文"的非确定性赌博，变成"命中即整篇父菜谱进上下文"的确定性保证。

  ## 一个具体实例（同一问题，开关 off vs on，取自同一对评测运行）

  **问题：生汆丸子汤的制作步骤是什么？**（该菜节点已被正确检索，hit@5=1）

  **改前 `enable_parent_doc_retrieval=False`（faithfulness 0.25）：**
  > 根据您提供的检索信息，**没有找到"生汆丸子汤"的具体制作步骤**。检索到的内容主要涉及米粉、蛏子、生菜等菜品的做法，以及"生汆丸子汤"的难度、时间和份量等基本信息。
  > 不过，我可以基于这些基本信息为您提供一份**通用且专业的生汆丸子汤制作指南**……
  > （随后模型凭通识编造了完整的"通用做法"——正是这种无依据补全导致 faithfulness 仅 0.25）

  **改后 `enable_parent_doc_retrieval=True`（faithfulness 0.96）：**
  > 第一步：准备肉馅 1. 将 **500克前腿肉（肥瘦比例3:7）** 切成小块……
  > 第二步：调制肉馅 2. 将 **80克葱姜花椒水** 分多次加入……3. 加入 **40克土豆淀粉**……
  > （步骤与用量来自该菜谱原文，非通识——父文档回填后内容确定性进入上下文）

  > 说明：该缺陷为概率性而非恒定——胜出 chunk 受检索上游 LLM 关键词抽取的运行随机性影响，同一问题偶尔也能答对。本改动的价值在于将"偶尔成功"变为"确定性成功"，而非修复一个恒定报错。

  ## 评测对比

  自建 100 题领域内评测集，同 router、同网络（开关 off vs on，唯一变量 `--parent_doc`）：

  | 指标 | 改前 (off) | 改后 (on) | 说明 |
  |---|---|---|---|
  | Hit@5 | 0.990 | 0.990 | 不变 |
  | Recall@5 | 0.915 | 0.915 | 不变 |
  | MRR@10 | 0.9391 | 0.9441 | ±0.005 原因在于 dual_level LLM 关键词抖动，与本改动无关 |
  | in-domain faithfulness 均值 | 0.739 | **0.852** | |
  | 缺陷集（hit@5=1 但 faithfulness<0.5，**23 条**）| — | **23/23 全回升**（持平 0、下降 0）| |

  缺陷集按问题类型 faithfulness 改前→改后均值：

  | 问题类型 | n | 改前 | 改后 |
  |---|---|---|---|
  | attribute_query | 3 | 0.323 | 0.778 |
  | entity_relation | 4 | 0.256 | 0.970 |
  | step_by_step | 5 | 0.285 | 0.712 |
  | causal | 10 | 0.174 | 0.574 |
  | multi_hop | 1 | 0.300 | 0.533 |

 父文档回填不改顺序、不改 node_id，评测 node_id 取自 metadata 非 page_content）→ 检索集合指标数学上不受影响；MRR 微小残差来自检索上游 LLM关键词抽取的随机性，非本改动引入。

  > 评测集与脚本可另作附件提供，本 PR 默认仅含代码改动。

  ## 兼容性
  - `enable_parent_doc_retrieval` 默认 `False` → 默认行为与改前完全一致
  - `hybrid_search(query, top_k)` 外部签名不变
  - 无新增第三方依赖