### PR TITLE
fix(C1): align AIHubmix API key configuration

### DIFF
--- a/code/C1/01_langchain_example.py
+++ b/code/C1/01_langchain_example.py
@@ -11,6 +11,13 @@ from langchain_openai import ChatOpenAI
 
 load_dotenv()
 
+aihubmix_api_key = os.getenv("AIHUBMIX_API_KEY")
+if not aihubmix_api_key:
+    raise ValueError(
+        "未检测到 AIHUBMIX_API_KEY，请先参考 docs/chapter1/02_preparation.md "
+        "配置 AIHubmix API 密钥。"
+    )
+
 markdown_path = "../../data/C1/markdown/easy-rl-chapter1.md"
 
 # 加载本地markdown文件
@@ -52,7 +59,7 @@ llm = ChatOpenAI(
     model="glm-4.7-flash-free",
     temperature=0.7,
     max_tokens=4096,
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
+    api_key=aihubmix_api_key,
     base_url="https://aihubmix.com/v1"
 )
 

--- a/code/C1/02_llamaIndex_example.py
+++ b/code/C1/02_llamaIndex_example.py
@@ -7,10 +7,17 @@ from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 
 load_dotenv()
 
+aihubmix_api_key = os.getenv("AIHUBMIX_API_KEY")
+if not aihubmix_api_key:
+    raise ValueError(
+        "未检测到 AIHUBMIX_API_KEY，请先参考 docs/chapter1/02_preparation.md "
+        "配置 AIHubmix API 密钥。"
+    )
+
 # 使用 AIHubmix
 Settings.llm = OpenAILike(
     model="glm-4.7-flash-free",
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
+    api_key=aihubmix_api_key,
     api_base="https://aihubmix.com/v1",
     is_chat_model=True
 )

--- a/docs/chapter1/02_preparation.md
+++ b/docs/chapter1/02_preparation.md
@@ -136,16 +136,16 @@ GitHub Codespaces 是 GitHub 提供的一项服务，允许开发者在云端创
     vim ~/.bashrc
     ```
 
-2.  输入 `i` 进入编辑模式，在文件末尾添加以下行，将 `[你的大模型 API 密钥]` 替换为你自己的密钥：
+2.  输入 `i` 进入编辑模式。教程中的 C1 示例默认使用 `AIHubmix`，请在文件末尾添加：
 
     ```bash
-    export DEEPSEEK_API_KEY=[你的大模型 API 密钥]
+    export AIHUBMIX_API_KEY=[你的 AIHubmix API 密钥]
     ```
 
-    如果选择的是 `AIHubmix` 平台，为了增加辨识度也可以使用：
+    如果将示例切换为注释中提供的 `DeepSeek` 配置，则改为设置：
 
     ```bash
-    export AIHUBMIX_API_KEY=[你的大模型 API 密钥]
+    export DEEPSEEK_API_KEY=[你的 DeepSeek API 密钥]
     ```
 
     > 不要带 `[]`
@@ -260,16 +260,16 @@ Cloud Studio 是腾讯云推出的一款基于浏览器的集成开发环境（I
     vim ~/.bashrc
     ```
 
-2.  输入 `i` 进入编辑模式，在文件末尾添加以下行，将 `[你的大模型 API 密钥]` 替换为你自己的密钥：
+2.  输入 `i` 进入编辑模式。教程中的 C1 示例默认使用 `AIHubmix`，请在文件末尾添加：
 
     ```bash
-    export DEEPSEEK_API_KEY=[你的大模型 API 密钥]
+    export AIHUBMIX_API_KEY=[你的 AIHubmix API 密钥]
     ```
 
-    如果选择的是 `AIHubmix` 平台，为了增加辨识度也可以使用：
+    如果将示例切换为注释中提供的 `DeepSeek` 配置，则改为设置：
 
     ```bash
-    export AIHUBMIX_API_KEY=[你的大模型 API 密钥]
+    export DEEPSEEK_API_KEY=[你的 DeepSeek API 密钥]
     ```
 
     > 不要带 `[]`
@@ -328,9 +328,11 @@ Cloud Studio 是腾讯云推出的一款基于浏览器的集成开发环境（I
 
     ![高级系统设置](./images/1_2_13.webp)
 
-4.  在 “环境变量” 对话框中，点击 “新建”（在 “用户变量” 部分下），然后输入以下信息：
-    - 变量名：DEEPSEEK_API_KEY
-    - 变量值：[你的 Deepseek API 密钥]
+4.  在 “环境变量” 对话框中，点击 “新建”（在 “用户变量” 部分下）。教程中的 C1 示例默认使用 `AIHubmix`，请输入：
+    - 变量名：`AIHUBMIX_API_KEY`
+    - 变量值：[你的 AIHubmix API 密钥]
+
+    如果将示例切换为注释中提供的 `DeepSeek` 配置，则使用变量名 `DEEPSEEK_API_KEY` 和对应的 DeepSeek API 密钥。
 
     ![高级系统设置](./images/1_2_14.webp)
 

--- a/docs/chapter1/03_get_start_rag.md
+++ b/docs/chapter1/03_get_start_rag.md
@@ -2,6 +2,8 @@
 
 通过第一节的学习，我们对RAG已经有了基本认识，并且也准备好了虚拟环境和api_key，接下来将尝试使用[**LangChain**](https://python.langchain.com/docs/introduction/)和[**LlamaIndex**](https://docs.llamaindex.ai/en/stable/)框架完成第一个RAG应用的实现与运行。通过一个示例，演示如何加载本地Markdown文档，利用嵌入模型处理文本，并结合大型语言模型（LLM）来回答与文档内容相关的问题。
 
+> 本节两个示例默认使用 AIHubmix。运行前请按照上一节配置 `AIHUBMIX_API_KEY`；如果改用代码注释中的 DeepSeek 配置，则设置 `DEEPSEEK_API_KEY`。
+
 ## 一、启动虚拟环境
 
 ### 1.1 激活虚拟环境
@@ -112,10 +114,17 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_deepseek import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 # 加载环境变量
 load_dotenv()
+
+aihubmix_api_key = os.getenv("AIHUBMIX_API_KEY")
+if not aihubmix_api_key:
+    raise ValueError(
+        "未检测到 AIHUBMIX_API_KEY，请先参考 docs/chapter1/02_preparation.md "
+        "配置 AIHubmix API 密钥。"
+    )
 ```
 
 ### 3.2 数据准备
@@ -196,11 +205,11 @@ load_dotenv()
         model="glm-4.7-flash-free",
         temperature=0.7,
         max_tokens=2048,
-        api_key=os.getenv("DEEPSEEK_API_KEY")
+        api_key=aihubmix_api_key,
         base_url="https://aihubmix.com/v1"
     )
     ```
-- **调用LLM生成答案并输出**: 将用户问题 (`question`) 和先前准备好的上下文 (`docs_content`) 格式化到提示模板中，然后调用ChatDeepSeek的`invoke`方法获取生成的答案。
+- **调用LLM生成答案并输出**: 将用户问题 (`question`) 和先前准备好的上下文 (`docs_content`) 格式化到提示模板中，然后调用 `ChatOpenAI` 客户端的 `invoke` 方法获取生成的答案。
     ```python
     answer = llm.invoke(prompt.format(question=question, context=docs_content))
     print(answer)
@@ -224,9 +233,16 @@ from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 
 load_dotenv()
 
+aihubmix_api_key = os.getenv("AIHUBMIX_API_KEY")
+if not aihubmix_api_key:
+    raise ValueError(
+        "未检测到 AIHUBMIX_API_KEY，请先参考 docs/chapter1/02_preparation.md "
+        "配置 AIHubmix API 密钥。"
+    )
+
 Settings.llm = OpenAILike(
     model="glm-4.7-flash-free",
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
+    api_key=aihubmix_api_key,
     api_base="https://aihubmix.com/v1",
     is_chat_model=True
 )


### PR DESCRIPTION
## 修改内容

- C1 的 LangChain 与 LlamaIndex 示例改为读取与默认 AIHubmix 端点一致的 `AIHUBMIX_API_KEY`
- 缺少密钥时提前给出明确错误和配置文档路径，避免由 SDK 抛出含混的 `OPENAI_API_KEY` 错误
- 同步 Codespaces、Cloud Studio、Windows 与教程代码片段中的环境变量说明
- 修正教程片段中的 `ChatOpenAI` 导入、缺失逗号及客户端名称

## 根因

C1 默认配置使用 `https://aihubmix.com/v1`，但代码读取 `DEEPSEEK_API_KEY`；准备文档则建议 AIHubmix 用户设置 `AIHUBMIX_API_KEY`。因此按文档配置后，客户端仍会收到空密钥。

## 验证

- `python3 -m compileall -q code/C1`
- `git diff --check`

Closes #125